### PR TITLE
Automatic startup fix using postAttachCommand and postCreateCommand, configured build tasks, and removed deprecated version property

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,11 +11,11 @@
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// This can be used to network with other containers or with the host.
-	// "forwardPorts": [3000, 5432],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "yarn install",
-	"postCreateCommand": "chmod 777 ./.devcontainer/postCreateCommand.sh && ./.devcontainer/postCreateCommand.sh"
+	"postCreateCommand": "chmod 777 ./.devcontainer/postCreateCommand.sh && ./.devcontainer/postCreateCommand.sh",
+	"postAttachCommand": "chmod 777 ./.devcontainer/postAttachCommand.sh && ./.devcontainer/postAttachCommand.sh"
 
 	// Configure tool-specific properties.
 	// "customizations": {},

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build: 

--- a/.devcontainer/postAttachCommand.sh
+++ b/.devcontainer/postAttachCommand.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# define directories
+SERVER_DIR="/workspaces/development-project-ksds/server/"
+CLIENT_DIR="/workspaces/development-project-ksds/client/"
+
+echo "Starting server"
+bash -c "cd $SERVER_DIR && npm run dev" &
+
+echo "Starting client"
+bash -c "cd $CLIENT_DIR && npm run dev" &
+
+wait

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -15,11 +15,3 @@ cd $CLIENT_DIR
 
 echo "Installing npm packages for the client"
 npm install
-
-echo "Starting server"
-bash -c "cd $SERVER_DIR && npm run dev" &
-
-echo "Starting client"
-bash -c "cd $CLIENT_DIR && npm run dev" &
-
-wait

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,38 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "npm",
+			"script": "dev",
+			"path": "server",
+			"problemMatcher": [],
+			"label": "start server",
+			"detail": "nodemon ./bin/www",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"type": "npm",
+			"script": "dev",
+			"path": "client",
+			"problemMatcher": [],
+			"label": "start client",
+			"detail": "vite --host 0.0.0.0",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"label": "start client and server",
+			"dependsOn": ["start server", "start client"],
+			"dependsOrder": "parallel",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		}
+	]
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # development-project-ksds
 development-project-ksds created by GitHub Classroom
+
+## Tasks
+There are three build tasks configured (can be quickly accessed with ctrl + shift + B):
+1. start server: launches the server on port 3000
+2. start client: launches the client on port 5173
+3. start client and server: runs the first and second build tasks.


### PR DESCRIPTION
Three build tasks have been added to quickly launch the client, the server, or both (can be quickly accessed with Ctrl + Shift + B).

A bug causing the `postCreateCommand.sh` script to hang when executed in codespaces has been fixed by moving the portion that launches the application into the `postAttachCommand.sh` script (which is executed using the `postAttachCommand` property in `devcontainer.json`).

This has introduced (or I've discovered) a bug that makes forwarded ports return 502: Bad Gateway, unless removed and re-added on rebuild. I am unaware of why this happens, but to fix it, you just need to remove the forwarded ports, and then add them back. To get the application to start up automatically on a rebuild, remove all the forwarded ports before rebuilding.

`version: 3.8` has been removed from the `docker-compose.yml` because it has been yelling at me about it being deprecated.