### PR TITLE
Play button moves input slider every 2 seconds while active

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,23 +1,137 @@
 <script setup>
+import { ref, watch, useTemplateRef } from 'vue';
 import BaseMap from './components/BaseMap.vue'
+
+const sliderTimeout = 2000; // miliseconds;
+const inputSlider = useTemplateRef("inputSlider");
+const inputValue = ref(null);
+
+var intervalId = null;
+var active = ref(false);
+
+const play = ref({
+    playOpacity: "100%"
+})
+
+const pause = ref({
+    pauseOpacity: "0%"
+})
+
+watch(() => active.value,
+    () => {
+        if (active.value) {
+            intervalId = window.setInterval(incrementSlider, sliderTimeout);
+        }
+        else {
+            window.clearInterval(intervalId);
+        }
+    })
+
+function playButtonClick() {
+    play.value.playOpacity = active.value ? "100%" : "0%";
+    pause.value.pauseOpacity = active.value ? "0%" : "100%";
+    active.value = !active.value;
+}
+
+function incrementSlider() {
+    const step = parseInt(inputSlider.value.value) + parseInt(inputSlider.value.step);
+    const clamp = Math.max(inputSlider.value.min, Math.min(inputSlider.value.max, step));
+    inputSlider.value.value = clamp
+    inputValue.value = clamp;
+}
 </script>
 
 <template>
-  <div class="app-container">
-    <input type="range" id="yearSlider" min="1860" max="2025" step="10" value="1860" />
-    <span id="yearLabel">1860</span>
-    <BaseMap />
+    <div class="app-container">
+        <div class="timeline">
+            <div class="yearSelection">
+                <input ref="inputSlider" type="range" id="yearSlider" min="1860" max="2025" step="10" value="1860" />
+                <button class="playButton" @click="playButtonClick">
+                    <svg viewBox="0 0 50 50">
+                        <path id="play-icon" d="M36,25L15,37L15,13Z"></path>
+                        <path id="pause-icon" d="M16,13L16,37M34,13L34,37"></path>
+                    </svg>
+                </button>
+            </div>
+            <span id="yearLabel">1860</span>
+        </div>
+    <BaseMap :inputValue="inputValue" />
   </div>
 </template>
 
 <style scoped>
 input {
-  width: 60%;
+    width: 60%;
+    margin-right: 10px;
 }
 
 .app-container {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.timeline {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+}
+
+.yearSelection {
+    width: 80%;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+
+.playButton {
+    width: 50px;
+    height: 50px;
+    padding: 0px;
+    background: #D3D3D3;
+    border: 0;
+    border-radius: 10px;
+    box-shadow: 0 5px 5px 2px rgba(0, 0, 0, 0.6);
+    cursor: pointer;
+    transition: all 1s ease, transform 200ms ease, box-shadow 200ms ease;
+}
+
+#play-icon {
+    fill: #5E5E5E;
+    stroke: #5E5E5E;
+    stroke-width: 2;
+    stroke-linejoin: bevel;
+    opacity: v-bind('play.playOpacity');
+    transition: all 1s ease, opacity 200ms;
+}
+
+#pause-icon {
+    fill: none;
+    stroke: #5E5E5E;
+    stroke-width: 10;
+    stroke-linecap: round;
+    opacity: v-bind('pause.pauseOpacity');
+    transition: all 1s ease, opacity 200ms;
+}
+
+.playButton:hover svg #play-icon{
+    fill: #808080;
+    stroke: #808080;
+}
+
+.playButton:hover svg #pause-icon {
+    stroke: #808080;
+}
+
+.playButton:hover {
+    background: #E5E4E2;
+}
+
+.playButton:active {
+    transform: translateY(5%);
+    box-shadow: 0 3px 5px 2px rgba(0, 0, 0, 0.4);
 }
 </style>

--- a/client/src/components/BaseMap.vue
+++ b/client/src/components/BaseMap.vue
@@ -11,6 +11,7 @@ import TimelineTransition from './TimelineTransition.vue';
 import * as d3 from 'd3';
 
 export default {
+    props: ["inputValue"],
     components: {
         StartupData,
         TimelineTransition
@@ -23,7 +24,6 @@ export default {
     },
     methods: {
         changeZoomLevel(new_level) {
-            console.log(new_level);
             this.zoom_level.value = new_level;
         },
         centerText(d, i, n, dy) {
@@ -116,7 +116,7 @@ export default {
 
         <!--Fetches and renders geojson data-->
         <StartupData :svgElement="svg" :projection="projection" @changeZoom="changeZoomLevel" />
-        <TimelineTransition :svgElement="svg" :projection="projection" @changeZoom="changeZoomLevel"/>
+        <TimelineTransition :svgElement="svg" :projection="projection" :inputValue="inputValue" @changeZoom="changeZoomLevel"/>
     </div>
 </template>
 

--- a/client/src/components/TimelineTransition.vue
+++ b/client/src/components/TimelineTransition.vue
@@ -7,20 +7,28 @@
  * geojson data when necessary.
  */
 import * as d3 from 'd3';
-import { defineEmits, defineProps, onMounted } from 'vue';
+import { defineEmits, defineProps, onMounted, watch } from 'vue';
 
 const emit = defineEmits(["changeZoom"]);
-const props = defineProps(["svgElement", "projection"]);
+const props = defineProps(["svgElement", "projection", "inputValue"]);
 
 onMounted(() => {
     const slider = d3.select("#yearSlider");
     const label = d3.select("#yearLabel");
 
+    // Called when the input slider
+    // is moved by the play button.
+    watch(() => props.inputValue,
+        (year) => {
+            label.text(year);
+            updateMap(year);
+        })
+
     //Whenever the slider is moved, updates label and map
-    slider.on("input", function() {
-    const year = +this.value;
-    label.text(year);
-    updateMap(year);
+    slider.on("change", function() {
+        const year = +this.value;
+        label.text(year);
+        updateMap(year);
     });
 })
 


### PR DESCRIPTION
Adds new play button next to the input slider

While the play button is active (pause icon shown) the input slider moves by 1 step every 2 seconds. It clamps the value to the input slider's min and max so it doesn't go over or under the allowed values.

`TimelineTransition.vue` now has a prop for the automatic change of the input slider value.

Closes #15 
